### PR TITLE
Fix issue with multiple where conditions.

### DIFF
--- a/lib/json_arel.rb
+++ b/lib/json_arel.rb
@@ -50,7 +50,11 @@ module JSONArel
       end
 
       # Evaluate.
-      table = table.where(node['where']) if node['where'].length > 0
+      if node['where'].length > 0
+        node['where'].each do |condition|
+          table = table.where(condition)
+        end
+      end
       expr = table.project(node['fields'])
 
       # TODO: support JOIN

--- a/spec/json_arel_spec.rb
+++ b/spec/json_arel_spec.rb
@@ -22,7 +22,7 @@ describe JSONArel::Resolver do
 
       it "should be able to resolve a simple query" do
         expect(subject.resolve).to eq(
-          "SELECT  * FROM \"lending_club_loans\" WHERE \"lending_club_loans\".\"loan_status\" IN (NULL), \"lending_club_loans\".\"loan_id\" = 1234, \"lending_club_loans\".\"loan_amount\" >= 123 LIMIT 100")
+          "SELECT  * FROM \"lending_club_loans\" WHERE \"lending_club_loans\".\"loan_status\" IN (NULL) AND \"lending_club_loans\".\"loan_id\" = 1234 AND \"lending_club_loans\".\"loan_amount\" >= 123 LIMIT 100")
       end
     end
 


### PR DESCRIPTION
Update test accordingly.
All tests passing.

Issue was how the table.where call was being made.  It was creating an array within an array and when the AREL source code looked through it, it dropped the ANDs because the length was one.